### PR TITLE
Make it compile with Qt < 5.5

### DIFF
--- a/src/leveldb/qqmlleveldb.h
+++ b/src/leveldb/qqmlleveldb.h
@@ -24,7 +24,7 @@ class Q_LEVELDB_EXPORT QQmlLevelDB : public QObject, public QQmlParserStatus
     Q_PROPERTY(bool opened READ opened NOTIFY openedChanged)
     Q_PROPERTY(QLevelDBOptions* options READ options)
     Q_INTERFACES(QQmlParserStatus)
-    Q_ENUM(QLevelDB::Status)
+    Q_ENUMS(QLevelDB::Status)
 public:
     explicit QQmlLevelDB(QObject *parent = nullptr);
 

--- a/src/leveldb/qqmlleveldbreadstream.cpp
+++ b/src/leveldb/qqmlleveldbreadstream.cpp
@@ -41,13 +41,10 @@ void QQmlLevelDBReadStream::componentComplete()
 
 void QQmlLevelDBReadStream::onNextKeyValue(QString key, QVariant value)
 {
-    QJSEngine *engine = qjsEngine(this);
-    if (!engine)
-        return;
     if (m_callback.isCallable()){
         QJSValueList list;
         list << QJSValue(key);
-        list << engine->toScriptValue<QVariant>(value);
+        list << m_engine.toScriptValue<QVariant>(value);
         m_callback.call(list);
     }
 }

--- a/src/leveldb/qqmlleveldbreadstream.h
+++ b/src/leveldb/qqmlleveldbreadstream.h
@@ -32,6 +32,7 @@ private slots:
     void onNextKeyValue(QString key, QVariant value);
 private:
     Q_DISABLE_COPY(QQmlLevelDBReadStream)
+    QJSEngine m_engine;
     QJSValue m_callback;
 };
 


### PR DESCRIPTION
1) Q_ENUM is not available in Qt < 5.5; use Q_ENUMS instead;
2) qjsEngine is not avialable in Qt < 5.5; use the old QJSEngine
