### PR TITLE
Add external synchronization to some leveldb classes

### DIFF
--- a/src/leveldb/qleveldb.cpp
+++ b/src/leveldb/qleveldb.cpp
@@ -326,6 +326,7 @@ bool QLevelDB::readStream(std::function<bool(QString, QVariant)> callback, const
     if (!it)
         return false;
 
+    QMutexLocker l(&m_mutex);
     if (!startKey.isEmpty())
         it->Seek(leveldb::Slice(startKey.toStdString()));
     else

--- a/src/leveldb/qleveldb.h
+++ b/src/leveldb/qleveldb.h
@@ -1,6 +1,7 @@
 #ifndef QLEVELDB_H
 #define QLEVELDB_H
 
+#include <QMutex>
 #include <QObject>
 #include <functional>
 #include <QSharedPointer>
@@ -76,6 +77,7 @@ private:
     bool m_opened;
     Status m_status;
     QString m_lastError;
+    QMutex m_mutex;
 
     void setStatus(Status status);
     void setLastError(QString text);

--- a/src/leveldb/qleveldbbatch.cpp
+++ b/src/leveldb/qleveldbbatch.cpp
@@ -37,6 +37,8 @@ QLevelDBBatch::~QLevelDBBatch()
 QLevelDBBatch* QLevelDBBatch::del(QString key)
 {
     m_operations.insert(key);
+
+    QMutexLocker l(&m_mutex);
     m_writeBatch->Delete(leveldb::Slice(key.toStdString()));
     return this;
 }
@@ -48,6 +50,8 @@ QLevelDBBatch* QLevelDBBatch::put(QString key, QVariant value)
 {
     QString json = variantToJson(value);
     m_operations.insert(key);
+
+    QMutexLocker l(&m_mutex);
     m_writeBatch->Put(leveldb::Slice(key.toStdString()),
                      leveldb::Slice(json.toStdString()));
     return this;
@@ -58,8 +62,10 @@ QLevelDBBatch* QLevelDBBatch::put(QString key, QVariant value)
 */
 QLevelDBBatch* QLevelDBBatch::clear()
 {
-    m_writeBatch->Clear();
     m_operations.clear();
+
+    QMutexLocker l(&m_mutex);
+    m_writeBatch->Clear();
     return this;
 }
 

--- a/src/leveldb/qleveldbbatch.h
+++ b/src/leveldb/qleveldbbatch.h
@@ -1,7 +1,7 @@
 #ifndef QLEVELDBBATCH_H
 #define QLEVELDBBATCH_H
 
-
+#include <QMutex>
 #include <QObject>
 #include <QSet>
 #include "qleveldbglobal.h"
@@ -32,6 +32,7 @@ private:
     QSharedPointer<leveldb::DB> m_levelDB;
     leveldb::WriteBatch *m_writeBatch;
     QSet<QString> m_operations;
+    QMutex m_mutex;
 };
 
 QT_END_NAMESPACE


### PR DESCRIPTION
The following classes require external synchronization (when calling non-
const methods) in order to work properly in multithreaded environments:
- leveldb::Iterator: Seek() / SeekToFirst() / Next()
- leveldb::WriteBatch: Delete() / Put() / Clear()
